### PR TITLE
SliceAndShuffle fix

### DIFF
--- a/tsgm/models/augmentations.py
+++ b/tsgm/models/augmentations.py
@@ -169,6 +169,8 @@ class SliceAndShuffle(BaseAugmenter):
                     slices.append(s)
                 slices.append(sequence[start_idx:])
                 np.random.shuffle(slices)
+            # concatenate the slices
+            sequence = np.concatenate(slices)
             synthetic_data.append(sequence)
             if has_labels:
                 new_labels.append(y[i])


### PR DESCRIPTION
Thanks for your great work. When I tried to use tsgm for time series data augmentation, it seemed that the SliceAndShuffle did not work.
The codes are as follows:
```python
import tsgm
import numpy as np
from matplotlib import pyplot as plt

# init a cosine time series
n_samples = 1
n_timesteps = 1000
n_features = 4
X = np.zeros((n_samples, n_timesteps, n_features))

for i in range(n_features):
    X[:, :, i] = 100*np.cos(np.linspace(i, 2 * np.pi + i, n_timesteps))


aug_model = tsgm.models.augmentations.GaussianNoise()
x1 = aug_model.generate(X=X, n_samples=1, variance=0.2)

aug_model = tsgm.models.augmentations.Shuffle()
x2 = aug_model.generate(X=X, n_samples=1)

aug_model = tsgm.models.augmentations.SliceAndShuffle()
x3 = aug_model.generate(X=X, n_samples=1, n_segments=3)

aug_model = tsgm.models.augmentations.MagnitudeWarping()
x4 = aug_model.generate(X=X, n_samples=1, sigma=1)

aug_model = tsgm.models.augmentations.WindowWarping()
x5 = aug_model.generate(X=X, n_samples=1, scales=(0.5,), window_ratio=0.5)


# show the original and augmented time series
plt.figure(figsize=(12, 8))
plt.subplot(231)
plt.plot(X.squeeze(0))
plt.title('Original')
plt.subplot(232)
plt.plot(x1.squeeze(0))
plt.title('GaussianNoise')
plt.subplot(233)
plt.plot(x2.squeeze(0))
plt.title('Shuffle')
plt.subplot(234)
plt.plot(x3.squeeze(0))
plt.title('SliceAndShuffle')
plt.subplot(235)
plt.plot(x4.squeeze(0))
plt.title('MagnitudeWarping')
plt.subplot(236)
plt.plot(x5.squeeze(0))
plt.title('WindowWarping')
plt.savefig('augmentations.png')
```
The results are shown in Fig. 1. We can see that there is no difference between the original data and SliceAndShuffle.
![Fig.1](https://github.com/AlexanderVNikitin/tsgm/assets/35948100/13d3c12a-3718-4173-9448-17c9e3d6c4b8)

I have checked the source codes of SliceAndShuffle, I found that the shuffled slices are not concatenated.
```python
       for i in seeds_idx:
            sequence = X[i]
            if self.per_channel:
                raise NotImplementedError(
                    "SliceAndShuffle separately by feature is not supported yet."
                )
            else:
                # Randomly pick n_segments-1 points where to slice
                idxs = np.random.randint(0, sequence.shape[0], size=n_segments - 1)
                slices = []
                start_idx = 0
                for j in sorted(idxs):
                    s = sequence[start_idx:j]
                    start_idx = j
                    slices.append(s)
                slices.append(sequence[start_idx:])
                np.random.shuffle(slices)
            # sequence is still X[i]
            synthetic_data.append(sequence)
```
New codes are:
```python
            sequence = np.concatenate(slices)
            synthetic_data.append(sequence)
```
Now the results are good as shown in Fig. 2.
![Fig. 2](https://github.com/AlexanderVNikitin/tsgm/assets/35948100/42821a7d-99ec-4a9e-84c8-a28c879f1844)

